### PR TITLE
Add ML Kit text recognition dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation libs.activity
     implementation libs.constraintlayout
     implementation libs.exif
+    implementation libs.mlkit.text.recognition
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 exif = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exif" }
+mlkit-text-recognition = { group = "com.google.mlkit", name = "text-recognition", version = "16.0.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add `mlkit-text-recognition` library definition
- use the new ML Kit text recognition in the app module

## Testing
- `./gradlew --version` *(fails: unable to download Gradle due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_687d41b6d52c8326bcfd0fa1338e9298